### PR TITLE
Improve command prompt

### DIFF
--- a/src/environment/home/.bashrc
+++ b/src/environment/home/.bashrc
@@ -1,3 +1,3 @@
 # The course's examples use a minimal prompt to limit distracting details. The
 # exercise environment should match.
-PS1='$ '
+PS1='vm$ '

--- a/src/material/01-intro/02-about-course/index.md
+++ b/src/material/01-intro/02-about-course/index.md
@@ -39,7 +39,7 @@ produced by the in response to the command.
 
 Note that terminal examples from other guides use the lone dollar sign
 character (`$`) or even the "hash" character (`#`) as the prompt. Whatever it
-looks like, the prompt's purpose is the same: to disignate the command that
+looks like, the prompt's purpose is the same: to designate the command that
 should be typed.
 
 ---
@@ -49,6 +49,7 @@ should be typed.
 ```
 pc$ this command should be run on your system
 this is output from your system
+
 vm$ this command should be run in the virtual machine
 this is output from the virtual machine
 ```
@@ -60,7 +61,7 @@ standalone process on your computer. This process is known as a "virtual
 machine." A small number of commands in this course are intended to be run on
 your system, but most of them should be executed within the virtual machine.
 
-The `pc$` prompt denotes commands that are inteded to be run on your system.
+The `pc$` prompt denotes commands that are intended to be run on your system.
 We'll use the `vm$` prompt to denote the commands that are intended for the
 virtual machine.
 

--- a/src/material/01-intro/02-about-course/index.md
+++ b/src/material/01-intro/02-about-course/index.md
@@ -17,6 +17,55 @@ that students will not have to rely on rote memorization to build confidence.
 
 ---
 
+# Conventions
+
+```
+pc$ code blocks like these represent a terminal
+they are intended to demonstrate various commands
+and their effects
+pc$
+```
+
+???
+
+Lines that begin with `pc$` describe commands that are intended to be entered
+into your system's terminal. The `pc$` is sometimes referred to as the
+"prompt", and it is intended to designate input lines. The "command" is all
+the text that follows the prompt; when typing the command on your system, you
+should not include the prompt.
+
+Lines that do not begin with the prompt are "output" lines. This is text
+produced by the in response to the command.
+
+Note that terminal examples from other guides use the lone dollar sign
+character (`$`) or even the "hash" character (`#`) as the prompt. Whatever it
+looks like, the prompt's purpose is the same: to disignate the command that
+should be typed.
+
+---
+
+:continued:
+
+```
+pc$ this command should be run on your system
+this is output from your system
+vm$ this command should be run in the virtual machine
+this is output from the virtual machine
+```
+
+???
+
+This course is designed to use a complete Unix-like system that runs as a
+standalone process on your computer. This process is known as a "virtual
+machine." A small number of commands in this course are intended to be run on
+your system, but most of them should be executed within the virtual machine.
+
+The `pc$` prompt denotes commands that are inteded to be run on your system.
+We'll use the `vm$` prompt to denote the commands that are intended for the
+virtual machine.
+
+---
+
 # About the exercises
 
 ![VirtualBox logo](logo-virtualbox.png)

--- a/src/material/01-intro/04-vagrant/index.md
+++ b/src/material/01-intro/04-vagrant/index.md
@@ -22,7 +22,7 @@ short commands.
 # Creating a virtual machine
 
 ```
-C:\speaking-nix\> vagrant up
+pc$ vagrant up
 ```
 
 ???
@@ -35,7 +35,7 @@ When we run the command `vagrant up` from a directory that has a file
 # Logging in to the virtual machine
 
 ```
-C:\speaking-nix\> vagrant ssh
+pc$ vagrant ssh
 Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-39-generic x86_64)
 
  * Documentation:  https://help.ubuntu.com/
@@ -55,7 +55,7 @@ Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-39-generic x86_64)
 
 0 packages can be updated.
 0 updates are security updates.
-$
+vm$
 ```
 
 ???
@@ -69,17 +69,16 @@ there's no need to worry about user names, passwords, or keys.
 # Get learnin'
 
 ```
-$ echo Hello, world!
+vm$ echo Hello, world!
 Hello, world!
-$ exit
-C:\speaking-nix\>
+vm$ exit
+pc$
 ```
 
 ???
 
-Now you're ready to go! The dollar sign character (`$`) is your command prompt.
-This is where you enter instructions--we'll be doing a lot of that in the
-coming sections.
+Now you're ready to go! The `vm$` is your command prompt. This is where you
+enter instructions--we'll be doing a lot of that in the coming sections.
 
 When you want to log out of the virtual machine, type `exit` and press `Enter`.
 
@@ -88,7 +87,7 @@ When you want to log out of the virtual machine, type `exit` and press `Enter`.
 # When you're done (for the day)
 
 ```
-C:\speaking-nix\> vagrant halt
+pc$ vagrant halt
 ```
 
 ???
@@ -102,13 +101,13 @@ done working. You can re-start the machine later with `vagrant up`.
 # When you're done (for good)
 
 ```
-C:\speaking-nix\> vagrant destroy
+pc$ vagrant destroy
     default: Are you sure you want to destroy the 'default' VM? [y/N] y
 ==> default: Forcing shutdown of VM...
 ==> default: Destroying VM and associated drives...
 ==> default: Removing hosts
 ==> default: Running cleanup tasks for 'shell' provisioner...
-C:\speaking-nix\> 
+vm$
 ```
 
 ???
@@ -121,14 +120,14 @@ hard drive. Use `vagrant destroy` when you don't need the environment anymore.
 # Live dangerously
 
 ```
-C:\speaking-nix\> vagrant up
-C:\speaking-nix\> vagrant ssh
-$ sudo rm -rf /bin
-$ echo Uh oh.
+pc$ vagrant up
+pc$ vagrant ssh
+vm$ sudo rm -rf /bin
+vm$ echo Uh oh.
 Uh oh.
-$ exit
-C:\speaking-nix\> vagrant destroy
-C:\speaking-nix\> vagrant up
+vm$ exit
+pc$ vagrant destroy
+pc$ vagrant up
 ```
 
 ???

--- a/src/material/01-intro/04-vagrant/index.md
+++ b/src/material/01-intro/04-vagrant/index.md
@@ -122,7 +122,7 @@ hard drive. Use `vagrant destroy` when you don't need the environment anymore.
 ```
 pc$ vagrant up
 pc$ vagrant ssh
-vm$ sudo rm -rf /bin
+vm$ bad --command "that really" messes-things.up
 vm$ echo Uh oh.
 Uh oh.
 vm$ exit

--- a/src/material/02-getting-your-bearings/01-file-system/index.md
+++ b/src/material/02-getting-your-bearings/01-file-system/index.md
@@ -40,7 +40,7 @@
 ---
 
 ```
-$
+vm$
 ```
 
 ???
@@ -58,9 +58,9 @@ $
 # `pwd`
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$
+vm$
 ```
 
 ???
@@ -78,12 +78,12 @@ $
 # `ls`
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$ ls
+vm$ ls
 my-amazing-subdirectory
 my-normal-file.txt
-$
+vm$
 ```
 
 ???
@@ -97,10 +97,10 @@ $
 :continued:
 
 ```
-$ ls my-amazing-subdirectory
+vm$ ls my-amazing-subdirectory
 oh-boy-another-directory
 just-another-file.txt
-$
+vm$
 ```
 
 ???
@@ -113,10 +113,10 @@ of that directory.
 # `cd`
 
 ```
-$ cd my-amazing-subdirectory
-$ pwd
+vm$ cd my-amazing-subdirectory
+vm$ pwd
 /home/sally/my-amazing-subdirectory
-$
+vm$
 ```
 
 ???
@@ -133,14 +133,14 @@ $
 :continued:
 
 ```
-$ ls
+vm$ ls
 oh-boy-another-directory
 just-another-file.txt
-$ cd just-another-file.txt
+vm$ cd just-another-file.txt
 cd: just-another-file.txt: Not a directory
-$ cd this-directory-doesnt-exist
+vm$ cd this-directory-doesnt-exist
 cd: this-directory-doesnt-exist: No such file or directory
-$
+vm$
 ```
 
 ???
@@ -152,12 +152,12 @@ Notice that we cannot move into a file or into a location that doesn't exist.
 :continued:
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$ cd my-amazing-subdirectory/oh-boy-another-directory
-$ pwd
+vm$ cd my-amazing-subdirectory/oh-boy-another-directory
+vm$ pwd
 /home/sally/my-amazing-subdirectory/oh-boy-another-directory
-$
+vm$
 ```
 
 ???
@@ -170,15 +170,15 @@ directory names.
 # Going `$HOME`
 
 ```
-$ pwd
+vm$ pwd
 /home/sally/my-amazing-subdirectory/oh-boy-another-directory
-$ cd ~
-$ pwd
+vm$ cd ~
+vm$ pwd
 /home/sally
-$ cd ~/my-amazing-subdirectory/oh-boy-another-directory
-$ pwd
+vm$ cd ~/my-amazing-subdirectory/oh-boy-another-directory
+vm$ pwd
 /home/sally/my-amazing-subdirectory/oh-boy-another-directory
-$
+vm$
 ```
 
 ???
@@ -201,12 +201,12 @@ directory."
 :continued:
 
 ```
-$ pwd
+vm$ pwd
 /home/sally/my-amazing-subdirectory/oh-boy-another-directory
-$ cd ..
-$ pwd
+vm$ cd ..
+vm$ pwd
 /home/sally/my-amazing-subdirectory
-$
+vm$
 ```
 
 ???
@@ -218,12 +218,12 @@ Two period characters (`..`) signify "the directory above."
 :continued:
 
 ```
-$ pwd
+vm$ pwd
 /home/sally/my-amazing-subdirectory
-$ cd ../../sally
-$ pwd
+vm$ cd ../../sally
+vm$ pwd
 /home/sally
-$
+vm$
 ```
 
 ???
@@ -236,13 +236,13 @@ can write a path.
 :continued:
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$ cd ../..
-$ pwd
+vm$ cd ../..
+vm$ pwd
 /
-$ cd ..
-$ pwd
+vm$ cd ..
+vm$ pwd
 /
 ```
 
@@ -269,15 +269,15 @@ directory**. We can't move any higher in the file system than the root.
 :continued:
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$ cd /home
-$ pwd
+vm$ cd /home
+vm$ pwd
 /home
-$ cd /home/sally/my-amazing-subdirectory
-$ pwd
+vm$ cd /home/sally/my-amazing-subdirectory
+vm$ pwd
 /home/sally/my-amazing-subdirectory
-$
+vm$
 ```
 
 ???
@@ -291,14 +291,14 @@ when we use it.
 # `tree`
 
 ```js
-$ tree
+vm$ tree
 .
 ├── my-amazing-directory
 │   └── just-another-file.txt
 └── my-normal-file.txt
 
 1 directory, 2 files
-$
+vm$
 ```
 
 ???
@@ -323,14 +323,14 @@ Lets take a look at some tools for learning about files and their contents.
 # `cat`
 
 ```
-$ ls
+vm$ ls
 oh-boy-another-directory
 just-another-file.txt
-$ cat just-another-file.txt
+vm$ cat just-another-file.txt
 This is the first line of just-another-file.txt
 This is the second line of the file!
 The file only has three lines, and this is the last one!
-$
+vm$
 ```
 
 ???
@@ -345,7 +345,7 @@ $
 # `less`
 
 ```
-$ less a-longer-file.txt
+vm$ less a-longer-file.txt
 This is the content of a-longer-file.txt, but only
 just enough of it to fill the screen. You can use
 the "up" and "down" arrow keys in the terminal to
@@ -368,13 +368,13 @@ has a lot of special controls, but the most important ones are:
 # `wc`
 
 ```
-$ cat just-another-file.txt
+vm$ cat just-another-file.txt
 This is the first line of just-another-file.txt
 This is the second line of the file!
 The file only has three lines, and this is the last one!
-$ wc just-another-file.txt
+vm$ wc just-another-file.txt
   3  27 142 just-another-file.txt
-$
+vm$
 ```
 
 The `wc` utility (short for "word count") displays the number of newlines,
@@ -385,15 +385,15 @@ words, and bytes in a given file. The output is pretty terse, though!
 # `sort`
 
 ```
-$ cat just-another-file.txt
+vm$ cat just-another-file.txt
 This is the first line of just-another-file.txt
 This is the second line of the file!
 The file only has three lines, and this is the last one!
-$ sort just-another-file.txt
+vm$ sort just-another-file.txt
 The file only has three lines, and this is the last one!
 This is the first line of just-another-file.txt
 This is the second line of the file!
-$
+vm$
 ```
 
 ???

--- a/src/material/02-getting-your-bearings/02-command-invocation/index.md
+++ b/src/material/02-getting-your-bearings/02-command-invocation/index.md
@@ -1,12 +1,12 @@
 
 ```
-$ ls
+vm$ ls
 my-amazing-subdirectory
 my-normal-file.txt
-$ ls my-amazing-subdirectory
+vm$ ls my-amazing-subdirectory
 oh-boy-another-directory
 just-another-file.txt
-$
+vm$
 ```
 
 ???
@@ -17,11 +17,11 @@ the program, optionally followed by some specific "target"
 ---
 
 ```
-$ LS_COLORS="di=42" ls -lr --all --sort=size music/*.mp3
+vm$ LS_COLORS="di=42" ls -lr --all --sort=size music/*.mp3
 Ace of Base - I Saw the Sign.mp3
 Santana - Smooth.mp3
 Mahler - Symphony No. 2 in C minor - 04 - Urlicht.mp3
-$
+vm$
 ```
 
 ???
@@ -39,11 +39,11 @@ $
 # The Executable
 
 ```
-$ pwd
+vm$ pwd
 /home/sally
-$ /bin/pwd
+vm$ /bin/pwd
 /home/sally
-$
+vm$
 ```
 
 ???
@@ -64,7 +64,7 @@ $
 # Path options
 
 ```
-$ ls ~/video ~/music
+vm$ ls ~/video ~/music
 ~/video:
 
 ~/music:
@@ -72,7 +72,7 @@ Ace of Base - I Saw the Sign.mp3
 Mahler - Symphony No. 2 in C minor - 04 - Urlicht.mp3
 Santana - Smooth.mp3
 Stallman - Free Software Song.ogg
-$
+vm$
 ```
 
 ???
@@ -87,11 +87,11 @@ $
 # Named options
 
 ```
-$ cat --number my-normal-file.txt
+vm$ cat --number my-normal-file.txt
      1 This is the first line of just-another-file.txt
      2 This is the second line of the file!
      3 The file only has three lines, and this is the last one!
-$
+vm$
 ```
 
 ???
@@ -107,7 +107,7 @@ $
 :continued:
 
 ```
-$ ls --sort=size ~/music
+vm$ ls --sort=size ~/music
 Stallman - Free Software Song.ogg
 Ace of Base - I Saw the Sign.mp3
 Santana - Smooth.mp3
@@ -122,11 +122,11 @@ option's behavior.
 ---
 
 ```
-$ cat --number --show-ends my-normal-file.txt
+vm$ cat --number --show-ends my-normal-file.txt
      1 This is the first line of just-another-file.txt$
      2 This is the second line of the file!$
      3 The file only has three lines, and this is the last one!$
-$
+vm$
 ```
 
 ???
@@ -136,23 +136,23 @@ Many options can be specified at the same time.
 ---
 
 ```
-$ cat -n --show-ends my-normal-file.txt
+vm$ cat -n --show-ends my-normal-file.txt
      1 This is the first line of just-another-file.txt$
      2 This is the second line of the file!$
      3 The file only has three lines, and this is the last one!$
-$ cat --number -E my-normal-file.txt
+vm$ cat --number -E my-normal-file.txt
      1 This is the first line of just-another-file.txt$
      2 This is the second line of the file!$
      3 The file only has three lines, and this is the last one!$
-$ cat -n -E my-normal-file.txt
+vm$ cat -n -E my-normal-file.txt
      1 This is the first line of just-another-file.txt$
      2 This is the second line of the file!$
      3 The file only has three lines, and this is the last one!$
-$ cat -nE my-normal-file.txt
+vm$ cat -nE my-normal-file.txt
      1 This is the first line of just-another-file.txt$
      2 This is the second line of the file!$
      3 The file only has three lines, and this is the last one!$
-$
+vm$
 ```
 
 ???
@@ -202,7 +202,7 @@ Fortunately, there are tools available for discovery.
 # `man`
 
 ```
-$ man ls
+vm$ man ls
 (1)                  User Commands                 LS(1)
 
 NAME
@@ -237,7 +237,7 @@ DESCRIPTION
 # `help`
 
 ```
-$ help cd
+vm$ help cd
 cd: cd [-L|[-P [-e]] [-@]] [dir]
     Change the shell working directory.
     
@@ -257,7 +257,7 @@ you're looking for.
 # The `--help` option
 
 ```
-$ cat --help
+vm$ cat --help
 Usage: cat [OPTION]... [FILE]...
 Concatenate FILE(s), or standard input, to standard output.
 
@@ -330,9 +330,9 @@ program invocation, it will work for *every* application.
 # `echo`
 
 ```
-$ echo Whatever we type here will be printed to the screen.
+vm$ echo Whatever we type here will be printed to the screen.
 Whatever we type here will be printed to the screen.
-$ echo Please expand the tilde character ~ there.
+vm$ echo Please expand the tilde character ~ there.
 Please expand the tilde character /home/sally there.
 ```
 
@@ -347,21 +347,21 @@ experiment with shell substitution.
 # Shell Expansion: `*`
 
 ```
-$ ls music
+vm$ ls music
 Ace of Base - I Saw the Sign.mp3
 Mahler - Symphony No. 2 in C minor - 04 - Urlicht.mp3
 Santana - Smooth.mp3
 Stallman - Free Software Song.ogg
-$ ls music/*.mp3
+vm$ ls music/*.mp3
 Ace of Base - I Saw the Sign.mp3
 Mahler - Symphony No. 2 in C minor - 04 - Urlicht.mp3
 Santana - Smooth.mp3
-$ ls music/S*
+vm$ ls music/S*
 Santana - Smooth.mp3
 Stallman - Free Software Song.ogg
-$ ls music/S*.mp3
+vm$ ls music/S*.mp3
 Santana - Smooth.mp3
-$
+vm$
 ```
 
 ???
@@ -379,11 +379,11 @@ with a list of files that match the rest of the characters.
 # Shell Expansion: Opting out
 
 ```
-$ echo I have ~ 2 oranges
+vm$ echo I have ~ 2 oranges
 I have /home/sally 2 oranges
-$ echo I have \~ 2 oranges
+vm$ echo I have \~ 2 oranges
 I have ~ 2 oranges
-$
+vm$
 ```
 
 ???
@@ -433,10 +433,10 @@ aspect of the system that effect the behavior of many commands.
 # Environment Variables: Definition
 
 ```
-$ export myVariable=my-variable-value
-$ echo Okay. Now what?
+vm$ export myVariable=my-variable-value
+vm$ echo Okay. Now what?
 Okay, Now what?
-$
+vm$
 ```
 
 ???
@@ -449,16 +449,16 @@ We can use the `export` utility to create and modify environment variables.
 
 
 ```
-$ export myVariable=variable-value
-$ echo The value of the variable "myVariable" is: $myVariable
+vm$ export myVariable=variable-value
+vm$ echo The value of the variable "myVariable" is: $myVariable
 The value of the variable "myVariable" is: variable-value
-$ export mistake=value with spaces
-$ echo The value of the variable "mistake" is: $mistake
+vm$ export mistake=value with spaces
+vm$ echo The value of the variable "mistake" is: $mistake
 The value of the variable "mistake" is: value
-$ export correct='value with spaces'
-$ echo The value of the variable "correct" is: $correct
+vm$ export correct='value with spaces'
+vm$ echo The value of the variable "correct" is: $correct
 The value of the variable "correct" is: value with spaces
-$
+vm$
 ```
 
 ???
@@ -470,17 +470,17 @@ To inspect them, another shell substitution feature comes to the rescue.
 # Environment Variables: Process Isolation
 
 ```
-$ export foo=bar
-$ echo $foo
+vm$ export foo=bar
+vm$ echo $foo
 bar
-$
+vm$
 ```
 
 In a new shell:
 
 ```
-$ echo $foo
-$
+vm$ echo $foo
+vm$
 ```
 
 ???
@@ -494,14 +494,14 @@ just close the terminal window and try again with a new one.
 # Under the hood: the `PATH` environment variable
 
 ```
-$ echo $PATH
+vm$ echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/sbin
-$ which ls
+vm$ which ls
 /bin/ls
-$ which man
+vm$ which man
 /usr/bin/man
-$ export PATH=garbage
-$ ls
+vm$ export PATH=garbage
+vm$ ls
 Command 'ls' is available in '/bin/ls'
 The command could not be located because '/bin' is not included in the PATH environment variable.
 ls: command not found
@@ -521,9 +521,9 @@ We can modify this value at our peril.
 # Under the hood: the `PS1` environment variable
 
 ```
-$ echo Prompt: $PS1
+vm$ echo Prompt: $PS1
 Prompt: $
-$ export PS1="my awesome prompt "
+vm$ export PS1="my awesome prompt "
 my awesome prompt echo Strange...
 Strange...
 my awesome prompt 

--- a/src/material/02-getting-your-bearings/03-process-mgmt-1/index.md
+++ b/src/material/02-getting-your-bearings/03-process-mgmt-1/index.md
@@ -13,7 +13,7 @@ processes and how you can regain control of the terminal in each.
 # Case #1: "I want to cancel this work"
 
 ```
-$ find / -name nemo
+vm$ find / -name nemo
 ```
 
 ???
@@ -35,9 +35,9 @@ Instead, we'll send a "signal" to the active process.
 :continued:
 
 ```
-$ find / -name nemo
+vm$ find / -name nemo
 ^C
-$
+vm$
 ```
 
 ???
@@ -54,7 +54,7 @@ re-enter the correct command.
 # Case #2: "I'm done entering data"
 
 ```
-$ sort
+vm$ sort
 murdock, matt
 stark, tony
 rogers, steve
@@ -80,7 +80,7 @@ we are done entering input and would like the program to continue its work.
 :continued:
 
 ```
-$ sort
+vm$ sort
 murdock, matt
 stark, tony
 rogers, steve
@@ -94,7 +94,7 @@ parker, peter
 rogers, steve
 romanova, natasha
 stark, tony
-$
+vm$
 ```
 
 ???
@@ -113,7 +113,7 @@ line directly.
 # Case #3: "I'd like to do other things while this completes."
 
 ```
-$ find / -name nemo
+vm$ find / -name nemo
 ```
 
 ???
@@ -128,10 +128,10 @@ inefficient (and may clutter up your desktop environment).
 :continued:
 
 ```
-$ find / -name nemo
+vm$ find / -name nemo
 ^Z
 [1]+  Stopped                 find / -name nemo
-$
+vm$
 ```
 
 ???
@@ -146,11 +146,11 @@ stop (but not exit) and release the terminal.
 :continued:
 
 ```
-$ jobs
+vm$ jobs
 [1]+  Stopped                 find / -name nemo
-$ bg 1
+vm$ bg 1
 [1]+ find / -name nemo &
-$ jobs
+vm$ jobs
 [1]+  Running                 find / -name nemo &
 ```
 
@@ -167,9 +167,9 @@ we want by ts "job ID" (`1` in this case).
 :continued:
 
 ```
-$ jobs
+vm$ jobs
 [1]+  Running                 find / -name nemo &
-$ fg 1
+vm$ fg 1
 ```
 
 ???

--- a/src/material/02-getting-your-bearings/04-sudo/index.md
+++ b/src/material/02-getting-your-bearings/04-sudo/index.md
@@ -12,9 +12,9 @@ There's one more topic that is important to understand: the `sudo` utility.
 # Background: Users and permissions
 
 ```
-$ whoami
+vm$ whoami
 sally
-$
+vm$
 ```
 
 ???
@@ -28,14 +28,14 @@ to promote privacy while still allowing people to share files and devices.
 :continued:
 
 ```
-$ echo $HOME
+vm$ echo $HOME
 /home/sally
-$ ls /home
+vm$ ls /home
 larry
 nancy
 sally
 xavier
-$
+vm$
 ```
 
 ???
@@ -49,9 +49,9 @@ there might be more directories for other people.
 :continued:
 
 ```
-$ ls /home/larry
+vm$ ls /home/larry
 ls: cannot open directory /home/larry: Permission denied
-$
+vm$
 ```
 
 ???
@@ -64,13 +64,13 @@ users.
 :continued:
 
 ```
-$ ls -o /home
+vm$ ls -o /home
 total 102
 drwx------ 72 larry  24576 Jul 01 10:55 larry
 drwx------ 72 nancy  8374  Jul 09 10:55 nancy
 drwx------ 72 sally  39827 Jul 14 10:55 sally
 drwx------ 72 xavier 33432 Jul 11 10:55 xavier
-$
+vm$
 ```
 
 ???
@@ -100,7 +100,7 @@ file system: `/root`.
 :continued:
 
 ```
-$ rm -rf /bin
+vm$ rm -rf /bin
 rm: cannot remove ‘/bin/zdiff’: Permission denied
 rm: cannot remove ‘/bin/findmnt’: Permission denied
 rm: cannot remove ‘/bin/bzegrep’: Permission denied
@@ -123,12 +123,12 @@ malicious program can do when it runs on your behalf.
 # `sudo`
 
 ```
-$ whoami
+vm$ whoami
 sally
-$ sudo whoami
+vm$ sudo whoami
 [sudo] password for sally:
 root
-$
+vm$
 ```
 
 ???
@@ -144,12 +144,12 @@ $
 :continued:
 
 ```
-$ whoami
+vm$ whoami
 untrusteduser
-$ sudo whoami
+vm$ sudo whoami
 [sudo] password for untrusteduser:
 untrusteduser is not in the sudoers file.  This incident will be reported.
-$
+vm$
 ```
 
 ???
@@ -163,19 +163,19 @@ administrator.
 :continued:
 
 ```
-$ sudo echo "After I've authenticated once..."
+vm$ sudo echo "After I've authenticated once..."
 [sudo] password for sally:
 After I've authenticated once...
-$ date
+vm$ date
 Wed Dec 31 1969 19:00:00 EST 1969
-$ sudo echo "I stay in 'sudo mode' for a little while."
+vm$ sudo echo "I stay in 'sudo mode' for a little while."
 I stay in 'sudo mode' for a little while.
-$ date
+vm$ date
 Wed Dec 31 1969 19:21:00 EST 1969
-$ sudo echo "...but I'll need to re-authenticate every so often."
+vm$ sudo echo "...but I'll need to re-authenticate every so often."
 [sudo] password for sally:
 ...but I'll need to re-authenticate every so often.
-$
+vm$
 ```
 
 ???
@@ -190,17 +190,17 @@ This status will expire after a short period (15 minutes by default).
 # Using `sudo` safely
 
 ```
-$ apt-get install cowsay
+vm$ apt-get install cowsay
 E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
 E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
-$ sudo apt-get install cowsay
+vm$ sudo apt-get install cowsay
 [sudo] password for sally: 
 Reading package lists... Done
 Building dependency tree       
 Reading state information... Done
 cowsay is already the newest version.
 0 upgraded, 0 newly installed, 0 to remove and 23 not upgraded.
-$
+vm$
 ```
 
 ???
@@ -215,11 +215,11 @@ understand what the command is going to do.
 # Avoiding "unsafe" uses of `sudo`
 
 ```
-$ sudo ./script-i-found-on-the-web.sh
+vm$ sudo ./script-i-found-on-the-web.sh
 [sudo] password for sally: 
 Installing a key logger... Done
 Deleting all your applications... Done
-$
+vm$
 ```
 
 ???
@@ -233,11 +233,11 @@ untrusted program from the Internet may cause all sorts of problems.
 :continued:
 
 ```
-$ sudo apt-get install the-dependency-i-need
+vm$ sudo apt-get install the-dependency-i-need
 [sudo] password for sally: 
-$ ./script-i-found-on-the-web.sh
+vm$ ./script-i-found-on-the-web.sh
 Performing actions as the current (de-privileged) user
-$
+vm$
 ```
 
 ???

--- a/src/material/03-improving-your-workflow/01-file-mgmt/index.md
+++ b/src/material/03-improving-your-workflow/01-file-mgmt/index.md
@@ -31,21 +31,21 @@ this course, we're concerned with the mainline use cases; you can consult the
 # `mv`
 
 ```
-$ ls good-guys
+vm$ ls good-guys
 dent-harvey.jpg
 fries-victor.jpg
 gordon-jim.jpg
 kyle-selina.jpg
 nigma-edward.jpg
-$ ls bad-guys
-$ mv good-guys/dent-harvey.jpg bad-guys
-$ ls good-guys
+vm$ ls bad-guys
+vm$ mv good-guys/dent-harvey.jpg bad-guys
+vm$ ls good-guys
 fries-victor.jpg
 gordon-jim.jpg
 kyle-selina.jpg
-$ ls bad-guys
+vm$ ls bad-guys
 dent-harvey.jpg
-$
+vm$
 ```
 
 ???
@@ -58,14 +58,14 @@ first option is the source and the second is the destination.
 :continued:
 
 ```
-$ mv good-guys/fries-victor.jpg good-guys/kyle-selina.jpg bad-guys
-$ ls good-guys
+vm$ mv good-guys/fries-victor.jpg good-guys/kyle-selina.jpg bad-guys
+vm$ ls good-guys
 gordon-jim.jpg
-$ ls bad-guys
+vm$ ls bad-guys
 dent-harvey.jpg
 fries-victor.jpg
 kyle-selina.jpg
-$
+vm$
 ```
 
 ???
@@ -80,9 +80,9 @@ expansion character.
 :continued:
 
 ```
-$ cd bad-guys
-$ mv dent-harvey.jpg twoface.jpg
-$ ls
+vm$ cd bad-guys
+vm$ mv dent-harvey.jpg twoface.jpg
+vm$ ls
 fries-victor.jpg
 kyle-selina.jpg
 twoface.jpg
@@ -99,8 +99,8 @@ from "moving" it between two names.
 :continued:
 
 ```
-$ cd ..
-$ mv bad-guys/twoface.jpg good-guys/dent-harvey.jpg
+vm$ cd ..
+vm$ mv bad-guys/twoface.jpg good-guys/dent-harvey.jpg
 ```
 
 ???
@@ -113,14 +113,14 @@ directory.
 # `rm`
 
 ```
-$ ls
+vm$ ls
 my-directory
 my-first-file
 my-second-file
-$ rm my-first-file my-second-file
-$ ls
+vm$ rm my-first-file my-second-file
+vm$ ls
 my-directory
-$
+vm$
 ```
 
 ???
@@ -132,13 +132,13 @@ We'll use `rm` to **r**e**m**ove files and directories.
 :continued:
 
 ```
-$ ls
+vm$ ls
 my-directory
-$ rm my-directory
+vm$ rm my-directory
 rm: cannot remove ‘dir’: Is a directory
-$ rm -r my-directory
-$ ls
-$
+vm$ rm -r my-directory
+vm$ ls
+vm$
 ```
 
 ???
@@ -152,11 +152,11 @@ often protects you from accidentally deleting things.
 # `mkdir`
 
 ```
-$ mkdir my-new-directory
-$ ls
+vm$ mkdir my-new-directory
+vm$ ls
 my-new-directory
-$ ls my-new-directory
-$
+vm$ ls my-new-directory
+vm$
 ```
 
 ???
@@ -184,7 +184,7 @@ ways to inspect their contents.
 # `grep`
 
 ```
-$ grep CSSConf index.html
+vm$ grep CSSConf index.html
 <h3 class="work-hed"><a href="http://2016.cssconf.com">CSSConf</a></h3>
 CSSConf is a conference dedicated to the designers, developers and engineers
 edge techniques, and tools. CSSConf US part of the international family of
@@ -204,7 +204,7 @@ text editor), so this is a case where rote memorization may be necessary.
 :continued:
 
 ```
-$ grep -E '<h[1-5]' index.html
+vm$ grep -E '<h[1-5]' index.html
 <h1 class="logo">
 <h2 class="mission">Open Design & Technology Services for
 <h3 class="section-hed"><strong>Partner with us</strong>
@@ -221,7 +221,7 @@ $ grep -E '<h[1-5]' index.html
 <h3 class="section-hed">Our team <strong>creates, champio
 <h2 class="section-hed">We'd love to hear from you. <stro
 <h2>Join our newsletter for Bocoup news you can use!</h2>
-$
+vm$
 ```
 
 ???
@@ -235,7 +235,7 @@ though, so don't worry if you're not comfortable using them.
 # `find`
 
 ```
-$ find src -name index.html
+vm$ find src -name index.html
 src/index.html
 src/birds/index.html
 src/birds/penguins/index.html
@@ -243,7 +243,7 @@ src/birds/puffins/index.html
 src/cereal/index.html
 src/cereal/capn-crunch/index.html
 src/cereal/fruit-loops/index.html
-$ 
+vm$ 
 ```
 
 ???
@@ -267,17 +267,17 @@ the user experience.
 :continued:
 
 ```
-$ find documents/recipes -name *carrot*
-$ echo *carrot*
+vm$ find documents/recipes -name *carrot*
+vm$ echo *carrot*
 giant-carrot.jpg
-$ echo \*carrot\*
+vm$ echo \*carrot\*
 *carrot*
-$ find documents/recipes -name \*carrot\*
+vm$ find documents/recipes -name \*carrot\*
 documents/recipes/appetizers/cold-carrot-soup.pdf
 documents/recipes/carrot-free
 documents/recipes/desserts/carrot-cake.odt
 documents/recipes/sides/carrots.pdf
-$ 
+vm$ 
 ```
 
 ???
@@ -310,7 +310,7 @@ Finally, we'll take a look at a few tools for modifying file contents.
 # `nano`
 
 ```
-$ nano hello.txt
+vm$ nano hello.txt
   GNU nano 2.2.6        File: hello.txt                      
 
 Hello, world!
@@ -339,13 +339,13 @@ somewhat truncated in the example above due to space limitations.
 # `sed`
 
 ```
-$ cat quote.txt
+vm$ cat quote.txt
 It's 106 miles to Chicago, we got a full tank of gas, half a pack of
 cigarettes, it's dark... and we're wearing sunglasses. 
-$ sed s/Chicago/Boston/ quote.txt
+vm$ sed s/Chicago/Boston/ quote.txt
 It's 106 miles to Boston, we got a full tank of gas, half a pack of
 cigarettes, it's dark... and we're wearing sunglasses. 
-$ 
+vm$ 
 ```
 
 ???
@@ -360,14 +360,14 @@ third forward slash character.
 :continued:
 
 ```
-$ cat quote.txt
+vm$ cat quote.txt
 It's 106 miles to Chicago, we got a full tank of gas, half a pack of
 cigarettes, it's dark... and we're wearing sunglasses. 
-$ sed --in-place s/Chicago/Boston/ quote.txt
-$ cat quote.txt
+vm$ sed --in-place s/Chicago/Boston/ quote.txt
+vm$ cat quote.txt
 It's 106 miles to Boston, we got a full tank of gas, half a pack of
 cigarettes, it's dark... and we're wearing sunglasses. 
-$ 
+vm$ 
 ```
 
 
@@ -384,7 +384,7 @@ option.
 :continued:
 
 ```
-$ sed -r s/(moz|webkit)R(equestAnimationFrame)/r\2/ -i src/utils/raf.js
+vm$ sed -r s/(moz|webkit)R(equestAnimationFrame)/r\2/ -i src/utils/raf.js
 ```
 
 ???
@@ -399,7 +399,7 @@ powerful way to automate text file transformations.
 # `awk`
 
 ```
-$ cat src/foo.css 
+vm$ cat src/foo.css 
 body {
   margin-left: 0;
   padding: 0;
@@ -408,14 +408,14 @@ table.data {
   color: red;
   margin: 0 1em;
 }
-$ awk '/\{/ { s = $0 } /margin/ { print s "\n" $0 "\n}" }' src/foo.css
+vm$ awk '/\{/ { s = $0 } /margin/ { print s "\n" $0 "\n}" }' src/foo.css
 body {
   margin-left: 0;
 }
 table.data {
   margin: 0 1em;
 }
-$ 
+vm$ 
 ```
 
 ???

--- a/src/material/04-managing-systems/01-process-mgmt-2/index.md
+++ b/src/material/04-managing-systems/01-process-mgmt-2/index.md
@@ -16,11 +16,11 @@ processes.
 # `ps`
 
 ```
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  1926 pts/0    00:00:00 ps
-$
+vm$
 ```
 
 ???
@@ -37,11 +37,11 @@ running bash and `ps` itself.
 :continued:
 
 ```
-$ ps -u
+vm$ ps -u
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 speaker   1892  0.0  0.7  21300  3756 pts/0    Ss   17:31   0:00 -bash
 speaker   1925  0.0  0.2  17168  1272 pts/0    R+   17:33   0:00 ps -u
-$
+vm$
 ```
 
 ???
@@ -59,7 +59,7 @@ an exhaustive overview.
 
 
 ```
-$ ps -aux
+vm$ ps -aux
 USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
 root         1  0.0  0.5  33600  2920 ?        Ss   17:30   0:00 /sbin/init
 root         2  0.0  0.0      0     0 ?        S    17:30   0:00 [kthreadd]
@@ -89,7 +89,7 @@ can see that many of the processes are actually owned by the "root" user.
 :continued:
 
 ```
-$ ps -aux | grep sleep
+vm$ ps -aux | grep sleep
 speaker   2079  0.0  0.1   5916   616 pts/0    S    18:31   0:00 sleep 3000
 speaker   2083  0.0  0.1  10464   892 pts/0    S+   18:31   0:00 grep sleep
 ```
@@ -106,7 +106,7 @@ a little confusing.
 :continued:
 
 ```
-$ ps -aux | grep slee[p]
+vm$ ps -aux | grep slee[p]
 speaker   2079  0.0  0.1   5916   616 pts/0    S    18:31   0:00 sleep 3000
 ```
 
@@ -131,12 +131,12 @@ management utilities recognize PIDs as references to processes.
 # `kill`
 
 ```
-$ ps -aux | grep slee[p]
+vm$ ps -aux | grep slee[p]
 speaker   2079  0.0  0.1   5916   616 pts/0    S    18:31   0:00 sleep 3000
-$ kill 2079
+vm$ kill 2079
 [1]+  Terminated              sleep 3000
-$ ps -aux | grep slee[p]
-$
+vm$ ps -aux | grep slee[p]
+vm$
 ```
 
 ???
@@ -150,20 +150,20 @@ $
 :continued:
 
 ```
-$ sleep 1000 &
+vm$ sleep 1000 &
 [1] 2526
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2526 pts/0    00:00:00 sleep
  2527 pts/0    00:00:00 ps
-$ kill -s sigint 2526
+vm$ kill -s sigint 2526
 [1]+  Interrupt               sleep 1000
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2529 pts/0    00:00:00 ps
-$
+vm$
 ```
 
 This is actually the second time we have run across signals in Unix-like
@@ -175,24 +175,24 @@ can do the same thing for any process using kill.
 :continued:
 
 ```
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2698 pts/0    00:00:03 rouge-process
  2699 pts/0    00:00:00 ps
-$ kill 2698
-$ ps
+vm$ kill 2698
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2698 pts/0    00:00:03 rouge-process
  2701 pts/0    00:00:00 ps
-$ kill -s sigkill 2698
+vm$ kill -s sigkill 2698
 [1]+  Killed                  rouge-process
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2703 pts/0    00:00:00 ps
-$ 
+vm$ 
 ```
 
 ???
@@ -209,7 +209,7 @@ exit gracefully. Keep this in mind as it may not be acceptable in all cases.
 # `killall`
 
 ```
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2708 pts/0    00:00:00 sleep
@@ -217,16 +217,16 @@ $ ps
  2710 pts/0    00:00:00 sleep
  2711 pts/0    00:00:00 sleep
  2712 pts/0    00:00:00 ps
-$ killall sleep
+vm$ killall sleep
 [1]   Terminated              sleep 1000
 [2]   Terminated              sleep 1000
 [3]-  Terminated              sleep 1000
 [4]+  Terminated              sleep 1000
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2714 pts/0    00:00:00 ps
-$
+vm$
 ```
 
 ???
@@ -241,14 +241,14 @@ reference...
 :continued:
 
 ```
-$ ps
+vm$ ps
   PID TTY          TIME CMD
  1892 pts/0    00:00:00 bash
  2719 pts/0    00:00:00 bash
  2724 pts/0    00:00:00 ps
-$ killall -9 bash
+vm$ killall -9 bash
 Connection to 127.0.0.1 closed.
-C:\>
+pc$
 ```
 
 ???
@@ -260,7 +260,7 @@ C:\>
 # `top`
 
 ```
-$ top
+vm$ top
 top - 19:50:44 up  2:19,  1 user,  load average: 0.00, 0.01, 0.05
 Tasks:  72 total,   1 running,  71 sleeping,   0 stopped,   0 zombie
 %Cpu(s):  0.0 us,  0.3 sy,  0.0 ni, 99.7 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st


### PR DESCRIPTION
Update all terminal examples to use `pc$` to designate the host
machine's command prompt and `vm$` to designate the guest machine's
command prompt. Explain this convention in the course introduction.
Update the virtual environment to use `vm$`.

---

Because the command in question is intended for demonstration purposes
only, a "fake" version is preferable because

- it will not cause damage if mistakenly entered in the host machine
- it has more meaning to students (who may not be familiar with `rm`)

Replace the "actually dangerous" command with such a "pseudo dangerous"
command.

/cc @cowboy @reconbot